### PR TITLE
Relax python version upper bound

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/DeepLabCut/DeepLabCut-live-GUI",
-    python_requires=">=3.5, <3.8",
+    python_requires=">=3.5, <3.11",
     install_requires=[
         "deeplabcut-live",
         "pyserial",


### PR DESCRIPTION
Allowing python <3.11 is in line with DLC and DLC-live!, and e.g. allows development in DLC's docker.
(Note that I tested it with python 3.8 and 3.9, but not 3.10)