### PR TITLE
Update README install instructions for PyPI release

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ You may install **PyTorch** or **TensorFlow** extras (or both), but you must cho
 - **PyTorch (recommended):**
 
 ```bash
-uv pip install deeplabcut-live-gui[pytorch]
+uv pip install --pre deeplabcut-live-gui[pytorch]
 ```
 
 - **TensorFlow (backwards compatibility):**
 
 ```bash
-uv pip install deeplabcut-live-gui[tf]
+uv pip install --pre deeplabcut-live-gui[tf]
 ```
 
 ---
@@ -88,13 +88,13 @@ conda activate dlclivegui
 - **PyTorch (recommended):**
 
 ```bash
-pip install deeplabcut-live-gui[pytorch]
+pip install --pre deeplabcut-live-gui[pytorch]
 ```
 
 - **TensorFlow:**
 
 ```bash
-pip install deeplabcut-live-gui[tf]
+pip install --pre deeplabcut-live-gui[tf]
 ```
 
 ## Run the application

--- a/README.md
+++ b/README.md
@@ -34,23 +34,17 @@ The new interface supports **multi-camera preview** with a **tiled display**, Py
 
 ## Installation
 
-While the previous `deeplabcut-live-gui` is available on PyPI, the newest PySide6-based GUI and features **must be obtained by installing from source**.
+`deeplabcut-live-gui` 2.0 is now available on PyPI.
 
 To get the **latest version**, please follow the **instructions below**.
 
-### 1) Clone the repository
-
-```bash
-git clone https://github.com/DeepLabCut/DeepLabCut-live-GUI.git
-cd DeepLabCut-live-GUI
-```
 
 ### Option A — Install with `uv`
 
-#### 2) Create & activate a new virtual environment
+#### 1) Create & activate a new virtual environment
 
 ```bash
-uv venv dlclivegui
+uv venv -p 3.12 dlclivegui
 
 # Linux/macOS:
 source dlclivegui/bin/activate
@@ -69,13 +63,13 @@ You may install **PyTorch** or **TensorFlow** extras (or both), but you must cho
 - **PyTorch (recommended):**
 
 ```bash
-uv pip install -e .[pytorch]
+uv pip install deeplabcut-live-gui[pytorch]
 ```
 
 - **TensorFlow (backwards compatibility):**
 
 ```bash
-uv pip install -e .[tf]
+uv pip install deeplabcut-live-gui[tf]
 ```
 
 ---
@@ -85,7 +79,7 @@ uv pip install -e .[tf]
 #### 1) Create & activate a new conda environment
 
 ```bash
-conda create -n dlclivegui python=3.12
+conda create -n dlclivegui python=3.12 # or mamba
 conda activate dlclivegui
 ```
 
@@ -94,13 +88,13 @@ conda activate dlclivegui
 - **PyTorch (recommended):**
 
 ```bash
-pip install -e .[pytorch]
+pip install deeplabcut-live-gui[pytorch]
 ```
 
 - **TensorFlow:**
 
 ```bash
-pip install -e .[tf]
+pip install deeplabcut-live-gui[tf]
 ```
 
 ## Run the application


### PR DESCRIPTION
Document that deeplabcut-live-gui 2.0 is available on PyPI and remove the previous "install from source" clone instructions. 

Update virtualenv (uv) instructions to use -p 3.12, switch pip commands from editable installs to installing the PyPI package (deeplabcut-live-gui[pytorch] / [tf]), and add a note to the conda creation command ("# or mamba"). 

- [x] Release to PyPi first
- [x] **NOTE** : currently aimed at full release, for rcs --pre will need to be added

These changes simplify installation by directing users to the PyPI package.