### PR TITLE
Decouple display and recording/inference FPS

### DIFF
--- a/dlclivegui/config.py
+++ b/dlclivegui/config.py
@@ -17,8 +17,16 @@ TriggerActivation = Literal["RisingEdge", "FallingEdge", "AnyEdge", "LevelHigh",
 TriggerStrobePolarity = Literal["ActiveHigh", "ActiveLow"]
 TriggerStrobeOperation = Literal["Exposure", "FixedDuration"]
 
-SINGLE_CAMERA_WORKER_DO_LOG_TIMING = False
-MULTI_CAMERA_WORKER_DO_LOG_TIMING = True
+# Global settings
+## GUI
+GUI_MAX_DISPLAY_FPS: float = 30.0
+
+
+## Debug
+### Timing logs
+SINGLE_CAMERA_WORKER_DO_LOG_TIMING: bool = True
+MULTI_CAMERA_WORKER_DO_LOG_TIMING: bool = True
+MAIN_WINDOW_DO_LOG_TIMING: bool = False
 
 
 class CameraSettings(BaseModel):

--- a/dlclivegui/config.py
+++ b/dlclivegui/config.py
@@ -26,7 +26,7 @@ GUI_MAX_DISPLAY_FPS: float = 30.0
 ### Timing logs
 SINGLE_CAMERA_WORKER_DO_LOG_TIMING: bool = True
 MULTI_CAMERA_WORKER_DO_LOG_TIMING: bool = True
-MAIN_WINDOW_DO_LOG_TIMING: bool = False
+# MAIN_WINDOW_DO_LOG_TIMING: bool = False
 
 
 class CameraSettings(BaseModel):

--- a/dlclivegui/gui/main_window.py
+++ b/dlclivegui/gui/main_window.py
@@ -772,7 +772,8 @@ class DLCLiveMainWindow(QMainWindow):
         self.bbox_color_combo.currentIndexChanged.connect(self._on_bbox_color_changed)
 
         # Multi-camera controller signals (used for both single and multi-camera modes)
-        self.multi_camera_controller.frame_ready.connect(self._on_multi_frame_ready)
+        self.multi_camera_controller.frame_ready.connect(self._on_multi_frame_processing_ready)
+        self.multi_camera_controller.frame_ready.connect(self._on_multi_frame_display_ready)
         self.multi_camera_controller.all_started.connect(self._on_multi_camera_started)
         self.multi_camera_controller.all_stopped.connect(self._on_multi_camera_stopped)
         self.multi_camera_controller.camera_error.connect(self._on_multi_camera_error)
@@ -1374,13 +1375,12 @@ class DLCLiveMainWindow(QMainWindow):
             )
         return output
 
-    def _on_multi_frame_ready(self, frame_data: MultiFrameData) -> None:
+    def _on_multi_frame_processing_ready(self, frame_data: MultiFrameData) -> None:
         """Handle frames from multiple cameras.
 
-        Priority order for performance:
+        Priority:
         1. DLC processing (highest priority - enqueue immediately, only for DLC camera)
         2. Recording (queued writes, non-blocking)
-        3. Display (lowest priority - tiled and updated on separate timer)
         """
         self._multi_camera_frames = frame_data.frames
         src_id = frame_data.source_camera_id
@@ -1437,7 +1437,12 @@ class DLCLiveMainWindow(QMainWindow):
             ts = frame_data.timestamps.get(src_id, time.time())
             self._rec_manager.write_frame(src_id, frame, ts)
 
-        # PRIORITY 3: Mark display dirty (tiling done in display timer)
+    def _on_multi_frame_display_ready(self, frame_data: MultiFrameData) -> None:
+        """Throttled UI/display path.
+
+        Called at GUI_MAX_DISPLAY_FPS, not at camera capture FPS for performance reasons.
+        """
+        self._multi_camera_frames = frame_data.frames
         self._display_dirty = True
 
     def _on_multi_camera_started(self) -> None:

--- a/dlclivegui/gui/main_window.py
+++ b/dlclivegui/gui/main_window.py
@@ -773,7 +773,7 @@ class DLCLiveMainWindow(QMainWindow):
 
         # Multi-camera controller signals (used for both single and multi-camera modes)
         self.multi_camera_controller.frame_ready.connect(self._on_multi_frame_processing_ready)
-        self.multi_camera_controller.frame_ready.connect(self._on_multi_frame_display_ready)
+        self.multi_camera_controller.display_ready.connect(self._on_multi_frame_display_ready)
         self.multi_camera_controller.all_started.connect(self._on_multi_camera_started)
         self.multi_camera_controller.all_stopped.connect(self._on_multi_camera_stopped)
         self.multi_camera_controller.camera_error.connect(self._on_multi_camera_error)

--- a/dlclivegui/services/multi_camera_controller.py
+++ b/dlclivegui/services/multi_camera_controller.py
@@ -117,10 +117,6 @@ class SingleCameraWorker(QObject):
                     continue
 
                 consecutive_errors = 0
-                # if True:  # TEMP FIXME REMOVE
-                # self._timing.note_frame()
-                # self._timing.maybe_log()
-                # continue
                 with self._timing.measure("Single.emit.frame_captured"):
                     self.frame_captured.emit(self._camera_id, frame, timestamp)
 

--- a/dlclivegui/services/multi_camera_controller.py
+++ b/dlclivegui/services/multi_camera_controller.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import logging
+import time
 from dataclasses import dataclass
 from functools import partial
 from threading import Event, Lock
@@ -19,6 +20,7 @@ from dlclivegui.cameras.factory import camera_identity_key
 
 # from dlclivegui.config import CameraSettings
 from dlclivegui.config import (
+    GUI_MAX_DISPLAY_FPS,
     MULTI_CAMERA_WORKER_DO_LOG_TIMING,
     SINGLE_CAMERA_WORKER_DO_LOG_TIMING,
     CameraSettings,
@@ -115,6 +117,10 @@ class SingleCameraWorker(QObject):
                     continue
 
                 consecutive_errors = 0
+                # if True:  # TEMP FIXME REMOVE
+                # self._timing.note_frame()
+                # self._timing.maybe_log()
+                # continue
                 with self._timing.measure("Single.emit.frame_captured"):
                     self.frame_captured.emit(self._camera_id, frame, timestamp)
 
@@ -224,7 +230,8 @@ class MultiCameraController(QObject):
     """Controller for managing multiple cameras simultaneously."""
 
     # Signals
-    frame_ready = Signal(object)  # MultiFrameData
+    frame_ready = Signal(object)  # MultiFrameData (full cam FPS; recording and inference only)
+    display_ready = Signal(object)  # MultiFrameData for GUI display (throttled to GUI_MAX_DISPLAY_FPS)
     camera_started = Signal(str, object)  # camera_id, settings
     camera_stopped = Signal(str)  # camera_id
     camera_error = Signal(str, str)  # camera_id, error_message
@@ -249,6 +256,9 @@ class MultiCameraController(QObject):
         self._failed_cameras: dict[str, str] = {}  # camera_id -> error message
         self._expected_cameras: int = 0  # Number of cameras we're trying to start
 
+        # GUI display max FPS (for throttling display updates when many cameras are active)
+        self._gui_display_max_fps: float = GUI_MAX_DISPLAY_FPS
+        self._gui_display_last_emit: float = 0.0
         # Performance logs
         self._timing_per_cam: dict[str, WorkerTimingStats] = {}
 
@@ -261,8 +271,6 @@ class MultiCameraController(QObject):
         return len(self._started_cameras)
 
     def _timing_for_camera(self, camera_id: str) -> WorkerTimingStats:
-        if not MULTI_CAMERA_WORKER_DO_LOG_TIMING:
-            return WorkerTimingStats(camera_id, enabled=False)
         timing = self._timing_per_cam.get(camera_id)
         if timing is None:
             timing = WorkerTimingStats(
@@ -273,6 +281,24 @@ class MultiCameraController(QObject):
             )
             self._timing_per_cam[camera_id] = timing
         return timing
+
+    def _should_emit_display_ready(self) -> bool:
+        """Return True when the UI/display path should be updated.
+
+        This only throttles display_ready. It must not throttle frame_ready,
+        because frame_ready is used for full-rate consumers such as recording.
+        """
+        if self._gui_display_max_fps <= 0:
+            return True
+
+        now = time.perf_counter()
+        min_interval = 1.0 / max(self._gui_display_max_fps, 1e-9)
+
+        if now - self._gui_display_last_emit < min_interval:
+            return False
+
+        self._gui_display_last_emit = now
+        return True
 
     def start(self, camera_settings: list[CameraSettings]) -> None:
         """Start multiple cameras."""
@@ -452,6 +478,11 @@ class MultiCameraController(QObject):
                 self.all_stopped.emit()
                 return
 
+        self._timing_per_cam.clear()
+        self._gui_display_last_emit = 0.0
+        self._workers.clear()
+        self._threads.clear()
+        self._settings.clear()
         self._started_cameras.clear()
         self._failed_cameras.clear()
         self._display_ids.clear()
@@ -516,6 +547,11 @@ class MultiCameraController(QObject):
             if frame_data is not None:
                 with timing.measure("Multi.emit.frame_ready"):
                     self.frame_ready.emit(frame_data)
+
+                # GUI-only path: throttled display updates
+                if self._should_emit_display_ready():
+                    with timing.measure("Multi.emit.display_ready"):
+                        self.display_ready.emit(frame_data)
 
         timing.note_frame()
         timing.maybe_log()

--- a/tests/gui/test_pose_overlay.py
+++ b/tests/gui/test_pose_overlay.py
@@ -65,7 +65,7 @@ def test_record_overlay_toggle_affects_frames_sent_to_recorder(window, recording
     # Provide a frame
     raw = np.zeros((100, 100, 3), dtype=np.uint8)
 
-    # Build minimal frame_data to call _on_multi_frame_ready
+    # Build minimal frame_data to call _on_multi_frame_processing_ready
     from dlclivegui.services.multi_camera_controller import MultiFrameData
 
     frame_data = MultiFrameData(
@@ -76,7 +76,7 @@ def test_record_overlay_toggle_affects_frames_sent_to_recorder(window, recording
 
     # 1) toggle OFF: should record raw
     window.record_with_overlays_checkbox.setChecked(False)
-    window._on_multi_frame_ready(frame_data)
+    window._on_multi_frame_processing_ready(frame_data)
 
     assert cam_id in recording_frame_spy
     recorded_off = recording_frame_spy[cam_id]
@@ -84,7 +84,7 @@ def test_record_overlay_toggle_affects_frames_sent_to_recorder(window, recording
 
     # 2) toggle ON: should record overlay frame (different)
     window.record_with_overlays_checkbox.setChecked(True)
-    window._on_multi_frame_ready(frame_data)
+    window._on_multi_frame_processing_ready(frame_data)
 
     recorded_on = recording_frame_spy[cam_id]
     assert not np.array_equal(recorded_on, raw)


### PR DESCRIPTION
## Motivation

This pull request introduces several improvements to multi-camera handling, frame rate configuration, and debugging/telemetry in the codebase. 
The main changes include 

- Decoupled high-frequency frame processing from display updates in the GUI (set to 30 FPS) 
  - Recording should now have more resources to follow requested FPS
  - Inference still uses only the latest unprocessed frame, making speed bottlenecked by inference only
  - GUI display is capped at 30 FPS now (configurable)
- Enhancing telemetry for camera frame rates, and adding utility functions for robust GenTL node values extraction
  - Fixes the incorrect FPS reporting for GenTL 

## Automated summary

**Multi-camera frame handling and GUI update throttling:**
- Separated high-frequency `frame_ready` signal (used for recording and inference) from the new `display_ready` signal (throttled to `GUI_MAX_DISPLAY_FPS` for efficient GUI updates) in `MultiCameraController`, with corresponding handler changes in `main_window.py` (`_on_multi_frame_processing_ready` and `_on_multi_frame_display_ready`). [[1]](diffhunk://#diff-e3419b210cc6aade2c514fc1f027cc9f883875093ad0d637f9ba5fb4356c0eafL229-R240) [[2]](diffhunk://#diff-e3419b210cc6aade2c514fc1f027cc9f883875093ad0d637f9ba5fb4356c0eafR264-R266) [[3]](diffhunk://#diff-e3419b210cc6aade2c514fc1f027cc9f883875093ad0d637f9ba5fb4356c0eafR290-R307) [[4]](diffhunk://#diff-e3419b210cc6aade2c514fc1f027cc9f883875093ad0d637f9ba5fb4356c0eafR411-R412) [[5]](diffhunk://#diff-e3419b210cc6aade2c514fc1f027cc9f883875093ad0d637f9ba5fb4356c0eafL392-R444) [[6]](diffhunk://#diff-e3419b210cc6aade2c514fc1f027cc9f883875093ad0d637f9ba5fb4356c0eafR462-R478) [[7]](diffhunk://#diff-f335012c11ae538931f73727ce5ccf288c304a4e10041d94b47d465cc4c4d7f1L772-R773) [[8]](diffhunk://#diff-f335012c11ae538931f73727ce5ccf288c304a4e10041d94b47d465cc4c4d7f1L1374-L1380) [[9]](diffhunk://#diff-f335012c11ae538931f73727ce5ccf288c304a4e10041d94b47d465cc4c4d7f1L1437-R1442) [[10]](diffhunk://#diff-045e1715b137eae4a4c90b442462977d126b723dd31ce5d7cceb72d8df2bfd17L68-R68)
- Added `GUI_MAX_DISPLAY_FPS` global setting and related debug flags in `config.py`.
- Updated signal connections and handler names in `main_window.py` to reflect the separation of processing and display paths. [[1]](diffhunk://#diff-f335012c11ae538931f73727ce5ccf288c304a4e10041d94b47d465cc4c4d7f1L772-R773) [[2]](diffhunk://#diff-f335012c11ae538931f73727ce5ccf288c304a4e10041d94b47d465cc4c4d7f1L1374-L1380) [[3]](diffhunk://#diff-f335012c11ae538931f73727ce5ccf288c304a4e10041d94b47d465cc4c4d7f1L1437-R1442)

**Camera frame rate configuration and telemetry improvements:**
- Improved frame rate configuration logic in `gentl_backend.py` to log before/after states, use more robust node selection, and set the actual FPS based on accepted values.
- Enhanced telemetry reading to prioritize resulting frame rate nodes, fall back to requested rates, and persist more telemetry data (e.g., exposure, gain, throughput, pixel format) for debugging and GUI display.

**Debugging and utility enhancements:**
- Added `_debug_frame_rate_nodes` for detailed logging of relevant GenICam node values, aiding in debugging frame rate issues. [[1]](diffhunk://#diff-6ff8914353ec397cc9e84cba1d967015491a0dc0295682f543eb40e1cac97c66R195-R233) [[2]](diffhunk://#diff-6ff8914353ec397cc9e84cba1d967015491a0dc0295682f543eb40e1cac97c66R513-R521)
- Implemented utility methods `_node_value`, `_node_float`, and `_node_str` for robust, best-effort extraction of node values, reducing boilerplate and error handling throughout the code.

These changes collectively make the system more robust for high-performance multi-camera setups and improve the ability to debug and monitor camera settings and telemetry.