### PR TITLE
Add hardware timestamp reporting

### DIFF
--- a/dlclivegui/cameras/backends/aravis_backend.py
+++ b/dlclivegui/cameras/backends/aravis_backend.py
@@ -11,7 +11,7 @@ import cv2
 import numpy as np
 
 from ...config import CameraSettings
-from ..base import CameraBackend, SupportLevel, register_backend
+from ..base import CameraBackend, CapturedFrame, SupportLevel, register_backend
 from ..factory import DetectedCamera
 
 LOG = logging.getLogger(__name__)
@@ -372,7 +372,7 @@ class AravisCameraBackend(CameraBackend):
 
         self._camera.start_acquisition()
 
-    def read(self) -> tuple[np.ndarray, float]:
+    def read(self) -> CapturedFrame:
         """Read a frame from the camera."""
         if self._camera is None or self._stream is None:
             raise RuntimeError("Aravis camera not initialized")
@@ -430,7 +430,7 @@ class AravisCameraBackend(CameraBackend):
             # Always push buffer back to stream
             self._stream.push_buffer(buffer)
 
-        return frame, timestamp
+        return CapturedFrame(frame=frame, software_timestamp=timestamp, timestamp_metadata=None)
 
     def stop(self) -> None:
         """Stop camera acquisition."""

--- a/dlclivegui/cameras/backends/basler_backend.py
+++ b/dlclivegui/cameras/backends/basler_backend.py
@@ -7,11 +7,10 @@ import logging
 import time
 from typing import ClassVar
 
-import numpy as np
-
 from ...config import BASLER_DO_LOG_TIMING, CameraTriggerSettings
 from ...utils.stats import WorkerTimingStats
-from ..base import CameraBackend, SupportLevel, register_backend
+from ...utils.timestamps import FrameTimestampMetadata
+from ..base import CameraBackend, CapturedFrame, SupportLevel, register_backend
 
 LOG = logging.getLogger(__name__)
 
@@ -58,6 +57,8 @@ class BaslerCameraBackend(CameraBackend):
         # (may skip StartGrabbing and converter setup for faster capability probing; not suitable for normal capture)
         self._fast_start: bool = bool(self.ns.get("fast_start", False))
         self._retrieve_timeout_ms: int = 100  # default; may be overridden by trigger settings
+        self._timestamp_tick_frequency_hz: float | None = None
+        self._last_frame_timestamp_metadata: FrameTimestampMetadata | None = None
 
         # ---- Trigger settings ----
         raw_trigger = self.ns.get("trigger", self._props.get("trigger"))
@@ -158,6 +159,10 @@ class BaslerCameraBackend(CameraBackend):
         return "Mono8" if self._should_output_mono() else "BGR8"
 
     @property
+    def last_frame_timestamp_metadata(self) -> FrameTimestampMetadata | None:
+        return self._last_frame_timestamp_metadata
+
+    @property
     def recommended_preserve_mono(self) -> bool | None:
         if not self._camera_pixel_format:
             return None
@@ -180,6 +185,7 @@ class BaslerCameraBackend(CameraBackend):
                 "stable_identity": SupportLevel.SUPPORTED,
                 "hardware_trigger": SupportLevel.BEST_EFFORT,
                 "preserve_mono": SupportLevel.SUPPORTED,
+                "hardware_frame_timestamps": SupportLevel.SUPPORTED,
             }
         )
         return caps
@@ -483,6 +489,7 @@ class BaslerCameraBackend(CameraBackend):
             "BslResultingAcquisitionFrameRate",
             "ExposureAuto",
             "ExposureTime",
+            "ExposureTimeAbs",
             "Width",
             "Height",
             "PixelFormat",
@@ -552,7 +559,10 @@ class BaslerCameraBackend(CameraBackend):
             try:
                 if hasattr(self._camera, "ExposureAuto"):
                     self._camera.ExposureAuto.SetValue("Off")
-                self._camera.ExposureTime.SetValue(float(self.settings.exposure))
+                if hasattr(self._camera, "ExposureTime"):
+                    self._camera.ExposureTime.SetValue(float(self.settings.exposure))
+                if hasattr(self._camera, "ExposureTimeAbs"):
+                    self._camera.ExposureTimeAbs.SetValue(float(self.settings.exposure))
                 LOG.info("[Basler] Exposure set to %s us (auto off)", self.settings.exposure)
             except Exception as exc:
                 LOG.warning("[Basler] Failed to set exposure: %s", exc)
@@ -663,9 +673,16 @@ class BaslerCameraBackend(CameraBackend):
             getattr(self.settings, "gain", None),
         )
 
-        # ----------------------------
+        # Get hardware tick frequency for timestamp conversion
+        try:
+            node = getattr(self._camera, "GevTimestampTickFrequency", None)
+            if node is not None and node.IsReadable():
+                self._timestamp_tick_frequency_hz = float(node.GetValue())
+                LOG.info("[Basler] timestamp tick frequency: %.3f Hz", self._timestamp_tick_frequency_hz)
+        except Exception:
+            LOG.debug("[Basler] Could not read GevTimestampTickFrequency", exc_info=True)
+
         # Persist stable identity into namespace
-        # ----------------------------
         try:
             serial = device.GetSerialNumber()
             if serial:
@@ -678,7 +695,29 @@ class BaslerCameraBackend(CameraBackend):
         except Exception:
             pass
 
-    def read(self) -> tuple[np.ndarray, float]:
+    def _make_timestamp_metadata(self, grab_result) -> FrameTimestampMetadata | None:
+        try:
+            ticks = int(grab_result.GetTimeStamp())
+        except Exception:
+            return None
+
+        freq = getattr(self, "_timestamp_tick_frequency_hz", None)
+        seconds = ticks / freq if freq and freq > 0 else None
+
+        return FrameTimestampMetadata(
+            source="grab_result.GetTimeStamp",
+            backend="basler",
+            default_reported="seconds" if seconds is not None else "raw_value",
+            seconds=seconds,
+            wall_clock_time=None,
+            raw_value=ticks,
+            raw_unit="ticks",
+            tick_frequency_hz=freq,
+            timebase="Basler camera timestamp counter",
+            kind="camera_clock",
+        )
+
+    def read(self) -> CapturedFrame:
         if self._camera is None:
             raise RuntimeError("Basler camera not opened")
         if self._converter is None:
@@ -707,6 +746,11 @@ class BaslerCameraBackend(CameraBackend):
             with self._timing.measure("Basler.get_array"):
                 frame = image.GetArray()
 
+            with self._timing.measure("Basler.timestamp"):
+                software_timestamp = time.time()
+                timestamp_metadata = self._make_timestamp_metadata(grab_result)
+                self._last_frame_timestamp_metadata = timestamp_metadata
+
             if not self._logged_first_frame:
                 self._logged_first_frame = True
                 LOG.info(
@@ -733,7 +777,11 @@ class BaslerCameraBackend(CameraBackend):
             self._timing.note_frame()
             self._timing.maybe_log()
 
-            return frame, time.time()
+            return CapturedFrame(
+                frame=frame,
+                software_timestamp=software_timestamp,
+                timestamp_metadata=timestamp_metadata,
+            )
 
         except Exception as exc:
             if grab_result is not None:

--- a/dlclivegui/cameras/backends/basler_backend.py
+++ b/dlclivegui/cameras/backends/basler_backend.py
@@ -58,7 +58,7 @@ class BaslerCameraBackend(CameraBackend):
         self._fast_start: bool = bool(self.ns.get("fast_start", False))
         self._retrieve_timeout_ms: int = 100  # default; may be overridden by trigger settings
         self._timestamp_tick_frequency_hz: float | None = None
-        self._last_frame_timestamp_metadata: FrameTimestampMetadata | None = None
+        self._timestamp_tick_frequency_source: str | None = None
 
         # ---- Trigger settings ----
         raw_trigger = self.ns.get("trigger", self._props.get("trigger"))
@@ -159,10 +159,6 @@ class BaslerCameraBackend(CameraBackend):
         return "Mono8" if self._should_output_mono() else "BGR8"
 
     @property
-    def last_frame_timestamp_metadata(self) -> FrameTimestampMetadata | None:
-        return self._last_frame_timestamp_metadata
-
-    @property
     def recommended_preserve_mono(self) -> bool | None:
         if not self._camera_pixel_format:
             return None
@@ -185,7 +181,7 @@ class BaslerCameraBackend(CameraBackend):
                 "stable_identity": SupportLevel.SUPPORTED,
                 "hardware_trigger": SupportLevel.BEST_EFFORT,
                 "preserve_mono": SupportLevel.SUPPORTED,
-                "hardware_frame_timestamps": SupportLevel.SUPPORTED,
+                "hardware_frame_timestamps": SupportLevel.BEST_EFFORT,
             }
         )
         return caps
@@ -678,9 +674,21 @@ class BaslerCameraBackend(CameraBackend):
             node = getattr(self._camera, "GevTimestampTickFrequency", None)
             if node is not None and node.IsReadable():
                 self._timestamp_tick_frequency_hz = float(node.GetValue())
-                LOG.info("[Basler] timestamp tick frequency: %.3f Hz", self._timestamp_tick_frequency_hz)
+                self._timestamp_tick_frequency_source = "GevTimestampTickFrequency"
+                LOG.info(
+                    "[Basler] timestamp tick frequency: %.3f Hz from GevTimestampTickFrequency",
+                    self._timestamp_tick_frequency_hz,
+                )
         except Exception:
             LOG.debug("[Basler] Could not read GevTimestampTickFrequency", exc_info=True)
+
+        if not self._timestamp_tick_frequency_hz or self._timestamp_tick_frequency_hz <= 0:
+            self._timestamp_tick_frequency_hz = 1_000_000_000.0
+            self._timestamp_tick_frequency_source = "assumed_default_1ghz"
+            LOG.info(
+                "[Basler] timestamp tick frequency unavailable; assuming %.3f Hz",
+                self._timestamp_tick_frequency_hz,
+            )
 
         # Persist stable identity into namespace
         try:
@@ -701,6 +709,10 @@ class BaslerCameraBackend(CameraBackend):
         except Exception:
             return None
 
+        if ticks == 0:
+            # Basler returns 0 if the timestamp is not available (e.g. for some GigE cameras)
+            return None
+
         freq = getattr(self, "_timestamp_tick_frequency_hz", None)
         seconds = ticks / freq if freq and freq > 0 else None
 
@@ -715,6 +727,9 @@ class BaslerCameraBackend(CameraBackend):
             tick_frequency_hz=freq,
             timebase="Basler camera timestamp counter",
             kind="camera_clock",
+            extra={
+                "tick_frequency_source": self._timestamp_tick_frequency_source,
+            },
         )
 
     def read(self) -> CapturedFrame:
@@ -749,7 +764,6 @@ class BaslerCameraBackend(CameraBackend):
             with self._timing.measure("Basler.timestamp"):
                 software_timestamp = time.time()
                 timestamp_metadata = self._make_timestamp_metadata(grab_result)
-                self._last_frame_timestamp_metadata = timestamp_metadata
 
             if not self._logged_first_frame:
                 self._logged_first_frame = True

--- a/dlclivegui/cameras/backends/gentl_backend.py
+++ b/dlclivegui/cameras/backends/gentl_backend.py
@@ -13,7 +13,7 @@ import cv2
 import numpy as np
 
 from ...config import CameraTriggerSettings
-from ..base import CameraBackend, SupportLevel, register_backend
+from ..base import CameraBackend, CapturedFrame, SupportLevel, register_backend
 from ..factory import DetectedCamera
 from .utils import gentl_discovery as cti_finder
 
@@ -621,7 +621,7 @@ class GenTLCameraBackend(CameraBackend):
             return f"{channels}ch-{frame.dtype}"
         return str(frame.dtype)
 
-    def read(self) -> tuple[np.ndarray, float]:
+    def read(self) -> CapturedFrame:
         if self._acquirer is None:
             raise RuntimeError("GenTL image acquirer not initialised")
 
@@ -661,7 +661,11 @@ class GenTLCameraBackend(CameraBackend):
                 pass
         self._actual_output_format = self._output_format_for_frame(frame)
 
-        return frame, timestamp
+        return CapturedFrame(
+            frame=frame,
+            software_timestamp=timestamp,
+            timestamp_metadata=None,
+        )
 
     def stop(self) -> None:
         if self._acquirer is not None:

--- a/dlclivegui/cameras/backends/opencv_backend.py
+++ b/dlclivegui/cameras/backends/opencv_backend.py
@@ -10,10 +10,9 @@ import time
 from typing import TYPE_CHECKING, Literal
 
 import cv2
-import numpy as np
 from pydantic import BaseModel, Field, model_validator
 
-from ..base import CameraBackend, SupportLevel, register_backend
+from ..base import CameraBackend, CapturedFrame, SupportLevel, register_backend
 from ..factory import DetectedCamera
 from .utils.opencv_discovery import (
     ModeRequest,
@@ -199,21 +198,45 @@ class OpenCVCameraBackend(CameraBackend):
 
         self._configure_capture()
 
-    def read(self) -> tuple[np.ndarray | None, float]:
-        """Robust frame read: return (None, ts) on transient failures; never raises."""
+    def read(self) -> CapturedFrame:
+        """Robust frame read: return CapturedFrame(frame=None, ...) on transient failures; never raises."""
         if self._capture is None:
             logger.warning("OpenCVCameraBackend.read() called before open()")
-            return None, time.time()
+            return CapturedFrame(
+                frame=None,
+                software_timestamp=time.time(),
+                timestamp_metadata=None,
+            )
+
         try:
             if not self._capture.grab():
-                return None, time.time()
+                return CapturedFrame(
+                    frame=None,
+                    software_timestamp=time.time(),
+                    timestamp_metadata=None,
+                )
+
             success, frame = self._capture.retrieve()
             if not success or frame is None or frame.size == 0:
-                return None, time.time()
-            return frame, time.time()
+                return CapturedFrame(
+                    frame=None,
+                    software_timestamp=time.time(),
+                    timestamp_metadata=None,
+                )
+
+            return CapturedFrame(
+                frame=frame,
+                software_timestamp=time.time(),
+                timestamp_metadata=None,
+            )
+
         except Exception as exc:
-            logger.debug(f"OpenCV read transient error: {exc}")
-            return None, time.time()
+            logger.debug("OpenCV read transient error: %s", exc)
+            return CapturedFrame(
+                frame=None,
+                software_timestamp=time.time(),
+                timestamp_metadata=None,
+            )
 
     def close(self) -> None:
         self._release_capture()

--- a/dlclivegui/cameras/base.py
+++ b/dlclivegui/cameras/base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -11,6 +12,7 @@ import numpy as np
 from ..config import CameraSettings
 
 if TYPE_CHECKING:
+    from ..utils.timestamps import FrameTimestampMetadata
     from .factory import DetectedCamera
 
 _BACKEND_REGISTRY: dict[str, type[CameraBackend]] = {}
@@ -72,7 +74,22 @@ DEFAULT_CAPABILITIES: dict[str, SupportLevel] = {
     "device_discovery": SupportLevel.UNSUPPORTED,
     "stable_identity": SupportLevel.UNSUPPORTED,
     "hardware_trigger": SupportLevel.UNSUPPORTED,
+    "hardware_frame_timestamps": SupportLevel.UNSUPPORTED,
 }
+
+
+@dataclass(frozen=True)
+class CapturedFrame:
+    """Frame plus software timestamp and optional backend timestamp metadata."""
+
+    frame: np.ndarray | None
+    software_timestamp: float
+    timestamp_metadata: FrameTimestampMetadata | None = None
+
+    def __iter__(self):
+        """Backwards-compatible unpacking: frame, software_timestamp = backend.read()"""
+        yield self.frame
+        yield self.software_timestamp
 
 
 class CameraBackend(ABC):
@@ -105,6 +122,11 @@ class CameraBackend(ABC):
 
     @property
     def recommended_preserve_mono(self) -> bool | None:
+        return None
+
+    @property
+    def last_frame_timestamp_metadata(self) -> FrameTimestampMetadata | None:
+        """Return backend-provided timestamp metadata for the last read frame."""
         return None
 
     @classmethod
@@ -171,7 +193,7 @@ class CameraBackend(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def read(self) -> tuple[np.ndarray, float]:
+    def read(self) -> CapturedFrame:
         """Read a frame and return the image with a timestamp."""
         raise NotImplementedError
 

--- a/dlclivegui/gui/main_window.py
+++ b/dlclivegui/gui/main_window.py
@@ -1399,7 +1399,9 @@ class DLCLiveMainWindow(QMainWindow):
             )
         return output
 
-    def _on_recording_frame_ready(self, camera_id: str, frame: np.ndarray, timestamp: float) -> None:
+    def _on_recording_frame_ready(
+        self, camera_id: str, frame: np.ndarray, timestamp: float, timestamp_metadata: object | None = None
+    ) -> None:
         """Handle full-rate per-camera frames for recording only.
 
         Intentionally lean:
@@ -1415,7 +1417,7 @@ class DLCLiveMainWindow(QMainWindow):
         if self.record_with_overlays_checkbox.isChecked():
             frame = self._render_overlays_for_recording(camera_id, frame)
 
-        self._rec_manager.write_frame(camera_id, frame, timestamp)
+        self._rec_manager.write_frame(camera_id, frame, timestamp, timestamp_metadata=timestamp_metadata)
 
     def _on_multi_frame_processing_ready(self, frame_data: MultiFrameData) -> None:
         """Handle frames from multiple cameras.

--- a/dlclivegui/gui/recording_manager.py
+++ b/dlclivegui/gui/recording_manager.py
@@ -202,12 +202,18 @@ class RecordingManager:
         self._session_dir = None
         self._run_dir = None
 
-    def write_frame(self, cam_id: str, frame: np.ndarray, timestamp: float | None = None) -> None:
+    def write_frame(
+        self, cam_id: str, frame: np.ndarray, timestamp: float | None = None, timestamp_metadata: object | None = None
+    ) -> None:
         rec = self._recorders.get(cam_id)
         if not rec or not rec.is_running:
             return
         try:
-            rec.write(frame, timestamp=timestamp if timestamp is not None else time.time())
+            rec.write(
+                frame,
+                timestamp=timestamp if timestamp is not None else time.time(),
+                timestamp_metadata=timestamp_metadata,
+            )
         except Exception as exc:
             log.warning("Failed to write frame for %s: %s", cam_id, exc)
             try:

--- a/dlclivegui/services/multi_camera_controller.py
+++ b/dlclivegui/services/multi_camera_controller.py
@@ -48,7 +48,7 @@ class MultiFrameData:
 class SingleCameraWorker(QObject):
     """Worker for a single camera in multi-camera mode."""
 
-    frame_captured = Signal(str, object, float)  # camera_id, frame, timestamp
+    frame_captured = Signal(str, object, float, object)  # camera_id, frame, timestamp, timestamp_metadata
     error_occurred = Signal(str, str)  # camera_id, error_message
     runtime_info = Signal(str, object)  # camera_id, dict of runtime info
     started = Signal(str)  # camera_id
@@ -118,7 +118,10 @@ class SingleCameraWorker(QObject):
         while not self._stop_event.is_set():
             try:
                 with self._timing.measure("Single.read"):
-                    frame, timestamp = self._backend.read()
+                    captured = self._backend.read()
+                    frame = captured.frame
+                    timestamp = captured.software_timestamp
+                    timestamp_metadata = captured.timestamp_metadata
                 if frame is None or frame.size == 0:
                     consecutive_errors += 1
                     if consecutive_errors >= self._max_consecutive_errors:
@@ -132,7 +135,7 @@ class SingleCameraWorker(QObject):
 
                 consecutive_errors = 0
                 with self._timing.measure("Single.emit.frame_captured"):
-                    self.frame_captured.emit(self._camera_id, frame, timestamp)
+                    self.frame_captured.emit(self._camera_id, frame, timestamp, timestamp_metadata)
 
                 self._timing.note_frame()
                 self._timing.maybe_log()
@@ -283,7 +286,9 @@ class MultiCameraController(QObject):
 
     # Signals
     frame_ready = Signal(object)  # MultiFrameData (full cam FPS; inference only)
-    recording_frame_ready = Signal(str, object, float)  # camera_id, frame, timestamp (full cam FPS; for recording)
+    recording_frame_ready = Signal(
+        str, object, float, object
+    )  # camera_id, frame, timestamp, timestamp_metadata (full cam FPS; for recording)
     display_ready = Signal(object)  # MultiFrameData for GUI display (throttled to GUI_MAX_DISPLAY_FPS)
     camera_started = Signal(str, object)  # camera_id, settings
     camera_stopped = Signal(str)  # camera_id
@@ -598,7 +603,9 @@ class MultiCameraController(QObject):
 
         self._maybe_finalize_stop()
 
-    def _on_frame_captured(self, camera_id: str, frame: np.ndarray, timestamp: float) -> None:
+    def _on_frame_captured(
+        self, camera_id: str, frame: np.ndarray, timestamp: float, timestamp_metadata: object | None = None
+    ) -> None:
         """Handle a frame from one camera."""
         timing = self._timing_for_camera(camera_id)
         frame_data: MultiFrameData | None = None
@@ -617,7 +624,7 @@ class MultiCameraController(QObject):
 
             if self._recording_frame_emission_enabled:
                 with timing.measure("Multi.emit.recording_frame_ready"):
-                    self.recording_frame_ready.emit(camera_id, frame, timestamp)
+                    self.recording_frame_ready.emit(camera_id, frame, timestamp, timestamp_metadata)
 
             with self._frame_lock:
                 with timing.measure("Multi.store_latest"):

--- a/dlclivegui/services/video_recorder.py
+++ b/dlclivegui/services/video_recorder.py
@@ -564,7 +564,7 @@ class VideoRecorder:
                     },
                     "hardware_timestamp": hardware_timestamp_source,
                 },
-                "hardware_frame_timestamps": frame_timestamps,
+                "frame_timestamps": frame_timestamps,
                 "start_time": software_timestamps[0] if software_timestamps else None,
                 "end_time": software_timestamps[-1] if software_timestamps else None,
                 "duration_seconds": (

--- a/dlclivegui/services/video_recorder.py
+++ b/dlclivegui/services/video_recorder.py
@@ -94,6 +94,7 @@ class VideoRecorder:
         self._writer: Any | None = None
         self._frame_size = frame_size
         self._frame_rate = frame_rate
+        self._hardware_timestamp_source: dict[str, Any] | None = None
         self._codec = codec
         self._crf = int(crf)
         self._buffer_size = max(1, int(buffer_size))
@@ -115,7 +116,7 @@ class VideoRecorder:
         self._written_times: deque[float] = deque(maxlen=600)
         self._encode_error: Exception | None = None
         self._last_log_time = 0.0
-        self._frame_timestamps: list[float] = []
+        self._frame_timestamps: list[dict[str, Any]] = []
         # Timing
         self._process_timing = WorkerTimingStats(
             f"RecorderProcess[{self._output.name}]", logger=logger, log_interval=1.0, enabled=REC_DO_LOG_TIMING
@@ -211,6 +212,7 @@ class VideoRecorder:
             self._last_latency = 0.0
             self._written_times.clear()
             self._frame_timestamps.clear()
+            self._hardware_timestamp_source = None
             self._encode_error = None
             self._stop_event.clear()
             self._writer_thread = threading.Thread(
@@ -224,7 +226,9 @@ class VideoRecorder:
         self._frame_size = frame_size
         self._frame_rate = frame_rate
 
-    def write(self, frame: np.ndarray, timestamp: float | None = None) -> bool:
+    def write(
+        self, frame: np.ndarray, timestamp: float | None = None, timestamp_metadata: object | None = None
+    ) -> bool:
         error = self._current_error()
         if error is not None:
             raise RuntimeError(f"Video encoding failed: {error}") from error
@@ -289,7 +293,7 @@ class VideoRecorder:
 
         try:
             with self._process_timing.measure("Recorder.queue_put"):
-                q.put((frame, timestamp), block=False)
+                q.put((frame, timestamp, timestamp_metadata), block=False)
         except queue.Full:
             with self._stats_lock:
                 self._dropped_frames += 1
@@ -432,7 +436,7 @@ class VideoRecorder:
                     if item is _SENTINEL:
                         break
                     else:
-                        frame, timestamp = item
+                        frame, timestamp, timestamp_metadata = item
                         start = time.perf_counter()
 
                         try:
@@ -442,6 +446,30 @@ class VideoRecorder:
 
                             with self._writer_timing.measure("Recorder.writer_write"):
                                 writer.write(frame)
+
+                            record: dict[str, Any] = {
+                                "frame_index": self._frames_written,
+                                "software_timestamp": float(timestamp),
+                            }
+
+                            if timestamp_metadata is not None:
+                                if (
+                                    hasattr(timestamp_metadata, "to_source_dict")
+                                    and self._hardware_timestamp_source is None
+                                ):
+                                    self._hardware_timestamp_source = timestamp_metadata.to_source_dict()
+
+                                if hasattr(timestamp_metadata, "to_frame_dict"):
+                                    record["hardware_timestamp"] = timestamp_metadata.to_frame_dict()
+                                    default_value = timestamp_metadata.get_default_reported()
+                                    if default_value is not None:
+                                        record["hardware_timestamp_default"] = default_value
+                                elif isinstance(timestamp_metadata, dict):
+                                    record["hardware_timestamp"] = dict(timestamp_metadata)
+                                else:
+                                    record["hardware_timestamp"] = repr(timestamp_metadata)
+
+                            self._frame_timestamps.append(record)
 
                         except Exception as exc:
                             with self._stats_lock:
@@ -459,7 +487,6 @@ class VideoRecorder:
                                 self._total_latency += elapsed
                                 self._last_latency = elapsed
                                 self._written_times.append(now)
-                                self._frame_timestamps.append(timestamp)
                                 if now - self._last_log_time >= 1.0:
                                     self._compute_write_fps_locked()
                                     self._last_log_time = now
@@ -506,27 +533,48 @@ class VideoRecorder:
             logger.info("No timestamps to save")
             return
 
-        # Create timestamps file path
         timestamp_file = self._output.with_suffix("").with_suffix(self._output.suffix + "_timestamps.json")
 
         try:
             with self._stats_lock:
-                timestamps = self._frame_timestamps.copy()
+                frame_timestamps = self._frame_timestamps.copy()
+                hardware_timestamp_source = (
+                    dict(self._hardware_timestamp_source) if self._hardware_timestamp_source is not None else None
+                )
 
-            # Prepare metadata
+            software_timestamps = [
+                float(rec["software_timestamp"]) for rec in frame_timestamps if "software_timestamp" in rec
+            ]
+
             data = {
+                "schema_version": 2,
                 "video_file": str(self._output.name),
-                "num_frames": len(timestamps),
-                "timestamps": timestamps,
-                "start_time": timestamps[0] if timestamps else None,
-                "end_time": timestamps[-1] if timestamps else None,
-                "duration_seconds": timestamps[-1] - timestamps[0] if len(timestamps) > 1 else 0.0,
+                "num_frames": len(frame_timestamps),
+                # Backward-compatible host/software timestamp list.
+                "timestamps": software_timestamps,
+                # New descriptive schema.
+                "timestamp_sources": {
+                    "software_timestamp": {
+                        "source": "host_time.time",
+                        "backend": "host",
+                        "kind": "software_wall_clock",
+                        "timebase": "Unix epoch",
+                        "unit": "seconds",
+                        "description": "Host-side software timestamp captured during acquisition.",
+                    },
+                    "hardware_timestamp": hardware_timestamp_source,
+                },
+                "hardware_frame_timestamps": frame_timestamps,
+                "start_time": software_timestamps[0] if software_timestamps else None,
+                "end_time": software_timestamps[-1] if software_timestamps else None,
+                "duration_seconds": (
+                    software_timestamps[-1] - software_timestamps[0] if len(software_timestamps) > 1 else 0.0
+                ),
             }
 
-            # Write to JSON
             with open(timestamp_file, "w") as f:
                 json.dump(data, f, indent=2)
 
-            logger.info(f"Saved {len(timestamps)} frame timestamps to {timestamp_file}")
+            logger.info("Saved %d frame timestamps to %s", len(frame_timestamps), timestamp_file)
         except Exception as exc:
-            logger.exception(f"Failed to save timestamps to {timestamp_file}: {exc}")
+            logger.exception("Failed to save timestamps to %s: %s", timestamp_file, exc)

--- a/dlclivegui/services/video_recorder.py
+++ b/dlclivegui/services/video_recorder.py
@@ -461,9 +461,10 @@ class VideoRecorder:
 
                                 if hasattr(timestamp_metadata, "to_frame_dict"):
                                     record["hardware_timestamp"] = timestamp_metadata.to_frame_dict()
-                                    default_value = timestamp_metadata.get_default_reported()
-                                    if default_value is not None:
-                                        record["hardware_timestamp_default"] = default_value
+                                    if hasattr(timestamp_metadata, "get_default_reported"):
+                                        default_value = timestamp_metadata.get_default_reported()
+                                        if default_value is not None:
+                                            record["hardware_timestamp_default"] = default_value
                                 elif isinstance(timestamp_metadata, dict):
                                     record["hardware_timestamp"] = dict(timestamp_metadata)
                                 else:

--- a/dlclivegui/services/video_recorder.py
+++ b/dlclivegui/services/video_recorder.py
@@ -550,9 +550,7 @@ class VideoRecorder:
                 "schema_version": 2,
                 "video_file": str(self._output.name),
                 "num_frames": len(frame_timestamps),
-                # Backward-compatible host/software timestamp list.
-                "timestamps": software_timestamps,
-                # New descriptive schema.
+                # "timestamps": software_timestamps,
                 "timestamp_sources": {
                     "software_timestamp": {
                         "source": "host_time.time",

--- a/dlclivegui/utils/timestamps.py
+++ b/dlclivegui/utils/timestamps.py
@@ -1,0 +1,82 @@
+# dlclivegui/utils/timestamps.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class FrameTimestampMetadata:
+    """Optional backend-provided timestamp metadata for a captured frame.
+
+    This supplements, but does not replace, the software timestamp.
+
+    Notes:
+        - `seconds` is in the backend/hardware timebase.
+        - `wall_clock_time` should only be set if the backend can confidently
+          provide Unix/wall-clock seconds.
+        - `raw_value` preserves the original device-specific timestamp.
+    """
+
+    source: str
+    backend: str
+
+    # Which value should downstream consumers use by default, if any.
+    # Expected values: "seconds", "wall_clock_time", or "raw_value".
+    default_reported: str | None = None
+
+    # Device/hardware timebase value, if convertible to seconds
+    seconds: float | None = None
+
+    # True Unix/wall-clock timestamp, if available
+    wall_clock_time: float | None = None
+
+    # Raw backend value, e.g. device clock ticks
+    raw_value: int | float | str | None = None
+    raw_unit: str | None = None
+
+    # Conversion metadata.
+    tick_frequency_hz: float | None = None
+    timebase: str | None = None
+
+    # e.g. "camera_clock", "ptp_camera_clock", "hardware_wall_clock",
+    # "frame_counter", "unknown"
+    kind: str = "unknown"
+
+    # Backend-specific extras.
+    extra: dict[str, Any] | None = None
+
+    def to_source_dict(self) -> dict[str, Any]:
+        """Return metadata that should be written once per recording stream."""
+        return {
+            "source": self.source,
+            "backend": self.backend,
+            "default_reported": self.default_reported,
+            "raw_unit": self.raw_unit,
+            "tick_frequency_hz": self.tick_frequency_hz,
+            "timebase": self.timebase,
+            "kind": self.kind,
+            "extra": self.extra or {},
+        }
+
+    def to_frame_dict(self) -> dict[str, Any]:
+        """Return defined per-frame timestamp values only."""
+        ts = {}
+        for k in ["seconds", "wall_clock_time", "raw_value"]:
+            v = getattr(self, k)
+            if v is not None:
+                ts[k] = v
+        return ts
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return full representation, useful for logging/debugging."""
+        return {
+            **self.to_source_dict(),
+            **self.to_frame_dict(),
+        }
+
+    def get_default_reported(self) -> int | float | str | None:
+        """Return the value selected by `default_reported`, if configured."""
+        if not self.default_reported:
+            return None
+        return self.to_frame_dict().get(self.default_reported)

--- a/tests/cameras/backends/conftest.py
+++ b/tests/cameras/backends/conftest.py
@@ -526,6 +526,9 @@ class FakePylon:
         def Release(self):
             self.released = True
 
+        def GetTimeStamp(self):
+            return 123456789
+
     class InstantCamera:
         def __init__(self, device):
             self._device = device
@@ -550,6 +553,7 @@ class FakePylon:
 
             self.AcquisitionFrameRateEnable = FakePylon._Feature(False)
             self.AcquisitionFrameRate = FakePylon._Feature(30.0)
+            self.GevTimestampTickFrequency = FakePylon._Feature(1_000_000_000.0)
 
             self.MaxNumBuffer = FakePylon._Feature(10)
 

--- a/tests/cameras/backends/test_aravis_backend.py
+++ b/tests/cameras/backends/test_aravis_backend.py
@@ -243,7 +243,7 @@ def make_backend(settings, buffers):
 
 @pytest.mark.unit
 def test_device_name():
-    be, cam, s = make_backend(Settings(), [])
+    be, _cam, s = make_backend(Settings(), [])
     assert be.device_name() == "FakeVendor FakeModel (12345)"
 
 
@@ -253,9 +253,9 @@ def test_read_mono8():
     data = (np.arange(w * h) % 256).astype(np.uint8).tobytes()
 
     buf = FakeAravis.Buffer(data, w, h, FakeAravis.PIXEL_FORMAT_MONO_8)
-    be, cam, s = make_backend(Settings(), [buf])
+    be, _cam, s = make_backend(Settings(), [buf])
 
-    frame, ts = be.read()
+    frame = be.read().frame
     assert frame.shape == (h, w, 3)
     assert frame.dtype == np.uint8
     # Ensure grayscale expanded to 3 channels
@@ -272,9 +272,9 @@ def test_read_rgb8_converts_to_bgr():
     data = np.array([255, 0, 0, 0, 255, 0], dtype=np.uint8).tobytes()
 
     buf = FakeAravis.Buffer(data, w, h, FakeAravis.PIXEL_FORMAT_RGB_8_PACKED)
-    be, cam, s = make_backend(Settings(), [buf])
+    be, _cam, s = make_backend(Settings(), [buf])
 
-    frame, _ = be.read()
+    frame = be.read().frame
     assert frame.shape == (1, 2, 3)
     # BGR conversion: red → [0,0,255], green → [0,255,0]
     assert (frame[0, 0] == np.array([0, 0, 255])).all()
@@ -288,9 +288,9 @@ def test_read_bgr8_passthrough():
     data = np.array([10, 20, 30, 40, 50, 60], dtype=np.uint8).tobytes()
 
     buf = FakeAravis.Buffer(data, w, h, FakeAravis.PIXEL_FORMAT_BGR_8_PACKED)
-    be, cam, s = make_backend(Settings(), [buf])
+    be, _cam, s = make_backend(Settings(), [buf])
 
-    frame, _ = be.read()
+    frame = be.read().frame
     assert frame.shape == (1, 2, 3)
     assert (frame.flatten() == np.array([10, 20, 30, 40, 50, 60])).all()
     assert s.pushed >= 1
@@ -302,9 +302,9 @@ def test_read_mono16_scaling():
     raw = np.array([0, 32768, 65535], dtype=np.uint16)
 
     buf = FakeAravis.Buffer(raw.tobytes(), w, h, FakeAravis.PIXEL_FORMAT_MONO_16)
-    be, cam, s = make_backend(Settings(), [buf])
+    be, _cam, s = make_backend(Settings(), [buf])
 
-    frame, _ = be.read()
+    frame = be.read().frame
     assert frame.shape == (1, 3, 3)
 
     # scaling: 0 → 0, max → 255, mid → ~128
@@ -320,9 +320,9 @@ def test_read_unknown_format_fallback_to_mono8():
     data = (np.arange(w * h) % 256).astype(np.uint8).tobytes()
     # Unknown token
     buf = FakeAravis.Buffer(data, w, h, "SOME_UNKNOWN_FMT")
-    be, cam, s = make_backend(Settings(), [buf])
+    be, _cam, s = make_backend(Settings(), [buf])
 
-    frame, _ = be.read()
+    frame = be.read().frame
     assert frame.shape == (h, w, 3)
     assert np.all(frame[..., 0] == frame[..., 1])
     assert np.all(frame[..., 1] == frame[..., 2])
@@ -331,7 +331,7 @@ def test_read_unknown_format_fallback_to_mono8():
 
 @pytest.mark.unit
 def test_read_timeout_raises():
-    be, cam, s = make_backend(Settings(), [])
+    be, _cam, s = make_backend(Settings(), [])
     with pytest.raises(TimeoutError):
         be.read()
 
@@ -341,7 +341,7 @@ def test_read_status_error_raises_and_pushes_back():
     w, h = 1, 1
     data = b"\x00"
     buf = FakeAravis.Buffer(data, w, h, FakeAravis.PIXEL_FORMAT_MONO_8, status="ERROR")
-    be, cam, s = make_backend(Settings(), [buf])
+    be, _cam, s = make_backend(Settings(), [buf])
 
     with pytest.raises(TimeoutError):
         be.read()
@@ -350,7 +350,7 @@ def test_read_status_error_raises_and_pushes_back():
 
 @pytest.mark.unit
 def test_close_is_idempotent():
-    be, cam, s = make_backend(Settings(), [])
+    be, _cam, s = make_backend(Settings(), [])
     be.close()
     be.close()  # should not raise
 

--- a/tests/cameras/backends/test_basler_backend.py
+++ b/tests/cameras/backends/test_basler_backend.py
@@ -21,7 +21,8 @@ def test_basler_open_starts_grabbing_and_read_returns_frame(patch_basler_sdk, ba
     assert be._camera.IsGrabbing()
     assert be._converter is not None
 
-    frame, ts = be.read()
+    payload = be.read()
+    frame, ts = payload.frame, payload.software_timestamp
     assert isinstance(ts, float)
     assert isinstance(frame, np.ndarray)
     assert frame.shape == (10, 10, 3)
@@ -257,7 +258,8 @@ def test_basler_default_trigger_is_off_and_free_runs(
     assert be._camera.TriggerMode.GetValue() == "Off"
     assert be.waits_for_hardware_trigger is False
 
-    frame, _ = be.read()
+    payload = be.read()
+    frame = payload.frame
     assert frame.shape == (10, 10, 3)
 
     be.close()
@@ -356,7 +358,8 @@ def test_basler_follower_non_strict_invalid_source_disables_trigger(
     assert be._camera.TriggerMode.GetValue() == "Off"
     assert be.waits_for_hardware_trigger is False
 
-    frame, _ = be.read()
+    payload = be.read()
+    frame = payload.frame
     assert frame.shape == (10, 10, 3)
 
     be.close()
@@ -430,7 +433,7 @@ def test_basler_software_trigger_requires_trigger_once_before_read(
     be.trigger_once()
     assert be._camera.software_trigger_calls == 1
 
-    frame, _ = be.read()
+    frame = be.read().frame
     assert frame.shape == (10, 10, 3)
 
     be.close()

--- a/tests/cameras/backends/test_basler_backend.py
+++ b/tests/cameras/backends/test_basler_backend.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+from dlclivegui.cameras.base import CapturedFrame
+from dlclivegui.utils.timestamps import FrameTimestampMetadata
+
 # ---------------------------------------------------------------------
 # Core lifecycle
 # ---------------------------------------------------------------------
@@ -507,3 +510,43 @@ def test_basler_hardware_trigger_maps_pylon_timeout_to_timeout_error(
 
     finally:
         backend.close()
+class TestBaslerFrameTimestamps:
+    @pytest.mark.unit
+    def test_read_returns_captured_frame_with_hardware_timestamp_metadata(
+        self,
+        patch_basler_sdk,
+        basler_settings_factory,
+    ):
+        import dlclivegui.cameras.backends.basler_backend as bb
+
+        settings = basler_settings_factory()
+        be = bb.BaslerCameraBackend(settings)
+        be.open()
+
+        captured = be.read()
+
+        assert isinstance(captured, CapturedFrame)
+        assert captured.frame is not None
+        assert isinstance(captured.software_timestamp, float)
+
+        meta = captured.timestamp_metadata
+        assert isinstance(meta, FrameTimestampMetadata)
+
+        assert meta.backend == "basler"
+        assert meta.source == "grab_result.GetTimeStamp"
+        assert meta.kind == "camera_clock"
+        assert meta.raw_unit == "ticks"
+        assert meta.raw_value == 123456789
+        assert meta.tick_frequency_hz == pytest.approx(1_000_000_000.0)
+        assert meta.seconds == pytest.approx(0.123456789)
+        assert meta.default_reported == "seconds"
+
+        source_dict = meta.to_source_dict()
+        assert source_dict["backend"] == "basler"
+        assert source_dict["source"] == "grab_result.GetTimeStamp"
+
+        frame_dict = meta.to_frame_dict()
+        assert frame_dict["seconds"] == pytest.approx(0.123456789)
+        assert frame_dict["raw_value"] == 123456789
+
+        be.close()

--- a/tests/cameras/backends/test_gentl_backend.py
+++ b/tests/cameras/backends/test_gentl_backend.py
@@ -54,12 +54,12 @@ def test_open_starts_stream_and_read_returns_frame(patch_gentl_sdk, gentl_settin
     assert be._acquirer is not None
 
     # Strict model validated via behavior: read must succeed after normal open()
-    frame, ts = be.read()
-    assert isinstance(ts, float)
-    assert isinstance(frame, np.ndarray)
-    assert frame.size > 0
+    captured = be.read()
+    assert isinstance(captured.software_timestamp, float)
+    assert isinstance(captured.frame, np.ndarray)
+    assert captured.frame.size > 0
     # Backend converts to BGR; ensure 3-channel output
-    assert frame.ndim == 3 and frame.shape[2] == 3
+    assert captured.frame.ndim == 3 and captured.frame.shape[2] == 3
 
     be.close()
     assert be._harvester is None
@@ -422,7 +422,7 @@ def test_pixel_format_unavailable_does_not_crash_open_and_streams(patch_gentl_sd
     be.open()
 
     # No fake-internal checks; just verify it can read
-    frame, _ = be.read()
+    frame = be.read().frame
     assert frame is not None and frame.size > 0
 
     be.close()

--- a/tests/cameras/backends/test_gentl_trigger.py
+++ b/tests/cameras/backends/test_gentl_trigger.py
@@ -289,7 +289,7 @@ def test_trigger_timeout_is_capped_for_hardware_trigger_fetch_polling(
         assert be._timeout == pytest.approx(expected_fetch_timeout)
 
         # Fake acquisition is started, so read should pass and record the capped timeout.
-        frame, _ = be.read()
+        frame = be.read().frame
         assert frame is not None
         assert be._acquirer.fetch_calls[-1] == pytest.approx(expected_fetch_timeout)
 

--- a/tests/cameras/backends/test_opencv_backend.py
+++ b/tests/cameras/backends/test_opencv_backend.py
@@ -124,7 +124,8 @@ def test_read_returns_none_on_grab_failure(fake_capture_factory):
     cap.grab_ok = False
     backend._capture = cap
 
-    frame, ts = backend.read()
+    payload = backend.read()
+    frame, ts = payload.frame, payload.software_timestamp
     assert frame is None
     assert isinstance(ts, float)
 
@@ -135,7 +136,8 @@ def test_read_returns_none_on_retrieve_failure(fake_capture_factory):
     cap.retrieve_ok = False
     backend._capture = cap
 
-    frame, ts = backend.read()
+    payload = backend.read()
+    frame, ts = payload.frame, payload.software_timestamp
     assert frame is None
     assert isinstance(ts, float)
 
@@ -150,7 +152,8 @@ def test_read_never_raises_on_exception(fake_capture_factory):
     cap.grab = boom
     backend._capture = cap
 
-    frame, ts = backend.read()
+    payload = backend.read()
+    frame, ts = payload.frame, payload.software_timestamp
     assert frame is None
     assert isinstance(ts, float)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ from PySide6.QtCore import Qt
 from dlclivegui.cameras import CameraFactory
 from dlclivegui.cameras.base import (
     CameraBackend,
+    CapturedFrame,
     SupportLevel,
     register_backend_direct,
     unregister_backend,
@@ -86,7 +87,7 @@ def make_backend_class(
                 raise RuntimeError("not opened")
             self._counter += 1
             frame = np.zeros(frame_shape, dtype=np.uint8)
-            return frame, float(timestamp_fn())
+            return CapturedFrame(frame=frame, software_timestamp=float(timestamp_fn()), timestamp_metadata=None)
 
     _TestBackend.__name__ = f"TestBackend_{name}"
     return _TestBackend
@@ -391,10 +392,10 @@ class FakeVideoRecorder:
     def stop(self):
         self.stopped = True
 
-    def write(self, frame, timestamp=None):
+    def write(self, frame, timestamp=None, timestamp_metadata=None):
         if self.raise_on_write:
             raise RuntimeError("write failed")
-        self.write_calls.append((frame, timestamp))
+        self.write_calls.append((frame, timestamp, timestamp_metadata))
         return True
 
     def get_stats(self):
@@ -418,7 +419,7 @@ def patch_video_recorder(monkeypatch):
 def recording_frame_spy(monkeypatch, window):
     captured = {}
 
-    def _fake_write_frame(cam_id, frame, timestamp=None):
+    def _fake_write_frame(cam_id, frame, timestamp=None, timestamp_metadata=None):
         captured[cam_id] = frame.copy()
 
     monkeypatch.setattr(window._rec_manager, "write_frame", _fake_write_frame)

--- a/tests/gui/test_rec_manager.py
+++ b/tests/gui/test_rec_manager.py
@@ -7,6 +7,7 @@ from dlclivegui.config import CameraSettings
 from dlclivegui.gui.recording_manager import RecordingManager
 from dlclivegui.services.multi_camera_controller import get_camera_id, get_display_id
 from dlclivegui.utils.stats import RecorderStats
+from dlclivegui.utils.timestamps import FrameTimestampMetadata
 
 
 @pytest.fixture
@@ -422,3 +423,41 @@ def test_start_all_passes_writegear_options(
         assert rec.writer_options["-crf"] == "23"
         assert rec.writer_options["-preset"] == "ultrafast"
         assert rec.writer_options["-tune"] == "zerolatency"
+
+
+class TestRecordingManagerTimestampMetadata:
+    @pytest.mark.unit
+    def test_write_frame_passes_timestamp_metadata(
+        self,
+        recording_settings,
+        _active_cams_two,
+        current_frames,
+        patch_video_recorder,
+        patch_build_run_dir,
+    ):
+        mgr = RecordingManager()
+        mgr.start_all(recording_settings, _active_cams_two, current_frames, session_name="Sess")
+
+        cam0_id = get_camera_id(_active_cams_two[0])
+        frame = current_frames[cam0_id]
+
+        meta = FrameTimestampMetadata(
+            source="grab_result.GetTimeStamp",
+            backend="basler",
+            default_reported="seconds",
+            seconds=0.001,
+            raw_value=1_000_000,
+            raw_unit="ticks",
+            tick_frequency_hz=1_000_000_000.0,
+            kind="camera_clock",
+        )
+
+        mgr.write_frame(cam0_id, frame, timestamp=123.0, timestamp_metadata=meta)
+
+        rec = mgr.recorders[cam0_id]
+        assert len(rec.write_calls) == 1
+
+        written_frame, written_timestamp, written_metadata = rec.write_calls[0]
+        assert written_frame is frame
+        assert written_timestamp == 123.0
+        assert written_metadata is meta

--- a/tests/services/test_multicam_controller.py
+++ b/tests/services/test_multicam_controller.py
@@ -1,4 +1,5 @@
 # tests/services/test_multicam_controller.py
+import numpy as np
 import pytest
 
 from dlclivegui.cameras.factory import CameraFactory
@@ -12,6 +13,7 @@ from dlclivegui.services.multi_camera_controller import (
     get_camera_id,
     get_display_id,
 )
+from dlclivegui.utils.timestamps import FrameTimestampMetadata
 
 
 @pytest.mark.unit
@@ -547,3 +549,50 @@ def test_recording_frame_ready_only_emits_when_enabled(qtbot, patch_factory):
     finally:
         with qtbot.waitSignal(mc.all_stopped, timeout=2000):
             mc.stop(wait=True)
+
+
+class TestRecordingFrameTimestamps:
+    @pytest.mark.unit
+    def test_recording_frame_ready_forwards_timestamp_metadata(self, qtbot):
+        mc = MultiCameraController()
+        mc._running = True
+        mc._recording_frame_emission_enabled = True
+
+        cam_id = "basler:0815-0000"
+        mc._settings[cam_id] = CameraSettings(
+            name="C",
+            backend="basler",
+            index=0,
+            enabled=True,
+        ).apply_defaults()
+        mc._camera_display_order = [cam_id]
+        mc._display_ids[cam_id] = "C"
+
+        frame = np.zeros((10, 10), dtype=np.uint8)
+        meta = FrameTimestampMetadata(
+            source="grab_result.GetTimeStamp",
+            backend="basler",
+            default_reported="seconds",
+            seconds=0.001,
+            raw_value=1_000_000,
+            raw_unit="ticks",
+            tick_frequency_hz=1_000_000_000.0,
+            kind="camera_clock",
+        )
+
+        seen = []
+
+        def on_recording_frame(camera_id, emitted_frame, timestamp, timestamp_metadata):
+            seen.append((camera_id, emitted_frame, timestamp, timestamp_metadata))
+
+        mc.recording_frame_ready.connect(on_recording_frame)
+
+        mc._on_frame_captured(cam_id, frame, 123.0, meta)
+
+        assert len(seen) == 1
+
+        camera_id, emitted_frame, timestamp, timestamp_metadata = seen[0]
+        assert camera_id == cam_id
+        assert emitted_frame is frame
+        assert timestamp == 123.0
+        assert timestamp_metadata is meta

--- a/tests/services/test_multicam_controller.py
+++ b/tests/services/test_multicam_controller.py
@@ -516,7 +516,7 @@ def test_recording_frame_ready_only_emits_when_enabled(qtbot, patch_factory):
     cam_id = get_camera_id(cam)
     seen: list[tuple[str, tuple, float]] = []
 
-    def on_recording_frame(camera_id, frame, timestamp):
+    def on_recording_frame(camera_id, frame, timestamp, timestamp_metadata=None):
         seen.append((camera_id, frame.shape, timestamp))
 
     mc.recording_frame_ready.connect(on_recording_frame)

--- a/tests/services/test_video_recorder.py
+++ b/tests/services/test_video_recorder.py
@@ -233,7 +233,6 @@ def test_stop_writes_timestamps_sidecar_json(patch_writegear, output_path, rgb_f
     assert data["end_time"] == 12.0
     assert data["duration_seconds"] == 2.0
     assert data["schema_version"] == 2
-    assert data["timestamps"] == [10.0, 12.0]
     assert data["timestamp_sources"]["hardware_timestamp"] is None
     assert data["frame_timestamps"][0]["software_timestamp"] == 10.0
     assert data["frame_timestamps"][1]["software_timestamp"] == 12.0
@@ -450,9 +449,6 @@ class TestVideoRecorderTimestampSidecar:
         assert data["video_file"] == output_path.name
         assert data["num_frames"] == 2
 
-        # Backward-compatible list.
-        assert data["timestamps"] == [10.0, 12.0]
-
         assert data["timestamp_sources"]["software_timestamp"]["kind"] == "software_wall_clock"
         assert data["timestamp_sources"]["hardware_timestamp"] is None
 
@@ -503,7 +499,6 @@ class TestVideoRecorderTimestampSidecar:
         assert data["num_frames"] == 1
 
         # Backward-compatible software timestamp list.
-        assert data["timestamps"] == [10.0]
         assert data["start_time"] == 10.0
         assert data["end_time"] == 10.0
         assert data["duration_seconds"] == 0.0

--- a/tests/services/test_video_recorder.py
+++ b/tests/services/test_video_recorder.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 
 import dlclivegui.services.video_recorder as vr_mod
+from dlclivegui.utils.timestamps import FrameTimestampMetadata
 
 # ----------------------------
 # Helpers
@@ -228,10 +229,14 @@ def test_stop_writes_timestamps_sidecar_json(patch_writegear, output_path, rgb_f
     data = json.loads(ts_path.read_text())
     assert data["video_file"] == output_path.name
     assert data["num_frames"] == 2
-    assert data["timestamps"] == [10.0, 12.0]
     assert data["start_time"] == 10.0
     assert data["end_time"] == 12.0
     assert data["duration_seconds"] == 2.0
+    assert data["schema_version"] == 2
+    assert data["timestamps"] == [10.0, 12.0]
+    assert data["timestamp_sources"]["hardware_timestamp"] is None
+    assert data["frame_timestamps"][0]["software_timestamp"] == 10.0
+    assert data["frame_timestamps"][1]["software_timestamp"] == 12.0
 
 
 def test_encoder_write_error_sets_encode_error_and_future_writes_raise(patch_writegear, output_path, rgb_frame):
@@ -418,3 +423,113 @@ def test_video_recorder_expands_gray_by_default(monkeypatch, tmp_path):
     rec.stop()
 
     assert written[0].shape == (10, 20, 3)
+
+
+class TestVideoRecorderTimestampSidecar:
+    def test_stop_writes_software_only_timestamp_sidecar_json(
+        self,
+        patch_writegear,
+        output_path,
+        rgb_frame,
+    ):
+        rec = vr_mod.VideoRecorder(output_path, buffer_size=10)
+        rec.start()
+
+        rec.write(rgb_frame, timestamp=10.0)
+        rec.write(rgb_frame, timestamp=12.0)
+
+        wait_until(lambda: len(FakeWriteGear.instances[0].frames) >= 2)
+        rec.stop()
+
+        ts_path = output_path.with_suffix("").with_suffix(output_path.suffix + "_timestamps.json")
+        assert ts_path.exists()
+
+        data = json.loads(ts_path.read_text())
+
+        assert data["schema_version"] == 2
+        assert data["video_file"] == output_path.name
+        assert data["num_frames"] == 2
+
+        # Backward-compatible list.
+        assert data["timestamps"] == [10.0, 12.0]
+
+        assert data["timestamp_sources"]["software_timestamp"]["kind"] == "software_wall_clock"
+        assert data["timestamp_sources"]["hardware_timestamp"] is None
+
+        assert data["frame_timestamps"] == [
+            {
+                "frame_index": 0,
+                "software_timestamp": 10.0,
+            },
+            {
+                "frame_index": 1,
+                "software_timestamp": 12.0,
+            },
+        ]
+
+    def test_stop_writes_hardware_timestamp_metadata_sidecar_json(
+        self,
+        patch_writegear,
+        output_path,
+        rgb_frame,
+    ):
+        rec = vr_mod.VideoRecorder(output_path, buffer_size=10)
+        rec.start()
+
+        meta = FrameTimestampMetadata(
+            source="grab_result.GetTimeStamp",
+            backend="basler",
+            default_reported="seconds",
+            seconds=0.001,
+            raw_value=1_000_000,
+            raw_unit="ticks",
+            tick_frequency_hz=1_000_000_000.0,
+            timebase="Basler camera timestamp counter",
+            kind="camera_clock",
+        )
+
+        rec.write(rgb_frame, timestamp=10.0, timestamp_metadata=meta)
+
+        wait_until(lambda: len(FakeWriteGear.instances[0].frames) >= 1)
+        rec.stop()
+
+        ts_path = output_path.with_suffix("").with_suffix(output_path.suffix + "_timestamps.json")
+        assert ts_path.exists()
+
+        data = json.loads(ts_path.read_text())
+
+        assert data["schema_version"] == 2
+        assert data["video_file"] == output_path.name
+        assert data["num_frames"] == 1
+
+        # Backward-compatible software timestamp list.
+        assert data["timestamps"] == [10.0]
+        assert data["start_time"] == 10.0
+        assert data["end_time"] == 10.0
+        assert data["duration_seconds"] == 0.0
+
+        # Static hardware source metadata is written once.
+        hw_source = data["timestamp_sources"]["hardware_timestamp"]
+        assert hw_source == {
+            "source": "grab_result.GetTimeStamp",
+            "backend": "basler",
+            "default_reported": "seconds",
+            "raw_unit": "ticks",
+            "tick_frequency_hz": 1_000_000_000.0,
+            "timebase": "Basler camera timestamp counter",
+            "kind": "camera_clock",
+            "extra": {},
+        }
+
+        # Per-frame records contain only per-frame values.
+        frame_ts = data["frame_timestamps"]
+        assert len(frame_ts) == 1
+
+        rec0 = frame_ts[0]
+        assert rec0["frame_index"] == 0
+        assert rec0["software_timestamp"] == 10.0
+        assert rec0["hardware_timestamp"] == {
+            "seconds": 0.001,
+            "raw_value": 1_000_000,
+        }
+        assert rec0["hardware_timestamp_default"] == 0.001

--- a/tests/utils/test_timestamps.py
+++ b/tests/utils/test_timestamps.py
@@ -1,0 +1,63 @@
+import pytest
+
+from dlclivegui.utils.timestamps import FrameTimestampMetadata
+
+
+class TestFrameTimestampMetadata:
+    def test_splits_source_and_frame_values(self):
+        meta = FrameTimestampMetadata(
+            source="grab_result.GetTimeStamp",
+            backend="basler",
+            default_reported="seconds",
+            seconds=0.123456789,
+            wall_clock_time=None,
+            raw_value=123456789,
+            raw_unit="ticks",
+            tick_frequency_hz=1_000_000_000.0,
+            timebase="Basler camera timestamp counter",
+            kind="camera_clock",
+        )
+
+        assert meta.to_source_dict() == {
+            "source": "grab_result.GetTimeStamp",
+            "backend": "basler",
+            "default_reported": "seconds",
+            "raw_unit": "ticks",
+            "tick_frequency_hz": 1_000_000_000.0,
+            "timebase": "Basler camera timestamp counter",
+            "kind": "camera_clock",
+            "extra": {},
+        }
+
+        frame_dict = meta.to_frame_dict()
+        assert frame_dict["seconds"] == pytest.approx(0.123456789)
+        assert frame_dict["raw_value"] == 123456789
+        assert "wall_clock_time" not in frame_dict
+
+        assert meta.get_default_reported() == pytest.approx(0.123456789)
+
+    def test_default_reported_raw_value(self):
+        meta = FrameTimestampMetadata(
+            source="device_counter",
+            backend="some_backend",
+            default_reported="raw_value",
+            raw_value=42,
+            raw_unit="frames",
+            kind="frame_counter",
+        )
+
+        assert meta.to_frame_dict() == {"raw_value": 42}
+        assert meta.get_default_reported() == 42
+
+    def test_unknown_default_field_returns_none(self):
+        meta = FrameTimestampMetadata(
+            source="device_counter",
+            backend="some_backend",
+            default_reported="seconds",
+            raw_value=42,
+            raw_unit="frames",
+            kind="frame_counter",
+        )
+
+        assert meta.to_frame_dict() == {"raw_value": 42}
+        assert meta.get_default_reported() is None


### PR DESCRIPTION
## Summary

Adds frame capture metadata and recording timestamp support, with best-effort Basler hardware timestamp integration.

This PR refactors camera reads to allow returning extra objects alongside the frame, such as the existing host-side software timestamp, as well as optional backend-provided timestamp metadata. 
The software timestamp remains the primary source, while hardware timestamps are added only when the backend can report them.

## Main changes

- Introduces a CapturedFrame wrapper for camera backends
- Adds generic timestamp metadata support
  - Supports hardware camera-clock timestamps, raw device ticks, optional wall-clock timestamps, and backend-specific extras
- Adds best-effort Basler hardware timestamp support
  - Reads device ticks count reported by Basler grab results when available
  - Falls back to an assumed one gigahertz tick frequency when the camera does not report one, and records that assumption in metadata. See [Basler docs](https://docs.baslerweb.com/timestamp#how-it-works), generally devices which cannot report tick frequency operate at 1GHz, hence the fallback.
  - Treats zero-valued Basler timestamps as unavailable, which handles cases such as pylon emulation or cameras that expose the API but do not provide usable timestamps, as per Basler docs.
- Updates non-Basler backends to return the new captured-frame object.
  - Aravis, GenTL, and OpenCV currently preserve software timestamps and do not provide hardware timestamp metadata for now.
- Threads timestamp metadata through the recording path.
  - RecordingManager forwards timestamp metadata into VideoRecorder.
- Updates recorder timestamp sidecar output.
  - Timestamp sidecars now use schema version 2.
  - Per-recording timestamp source metadata is stored once.
  - Hardware timestamp fields are omitted when unavailable.
- Improves Basler exposure compatibility
  - Sets both ExposureTime and ExposureTimeAbs when writable as they both control the same property on different devices

## What this does not do yet

- Hardware timestamps are best effort and backend-dependent.
- This does not change recording throughput or move recorder enqueueing off the GUI thread.

## Testing

Added and updated tests accordingly; tested and confirmed to work as intended with 1x a2A1920-160umPRO.