### PR TITLE
Fixes to avoid data loss

### DIFF
--- a/dlclivegui/gui/main_window.py
+++ b/dlclivegui/gui/main_window.py
@@ -2364,6 +2364,10 @@ class DLCLiveMainWindow(QMainWindow):
 
     def _stop_inference(self, show_message: bool = True) -> None:
         was_active = self._dlc_active
+
+        if self._rec_manager.is_active:
+            self._save_processor_data_if_available()
+
         self._dlc_active = False
         self._dlc_initialized = False
         self._dlc.reset()

--- a/dlclivegui/gui/main_window.py
+++ b/dlclivegui/gui/main_window.py
@@ -2364,10 +2364,6 @@ class DLCLiveMainWindow(QMainWindow):
 
     def _stop_inference(self, show_message: bool = True) -> None:
         was_active = self._dlc_active
-
-        if self._rec_manager.is_active:
-            self._save_processor_data_if_available()
-
         self._dlc_active = False
         self._dlc_initialized = False
         self._dlc.reset()

--- a/dlclivegui/gui/main_window.py
+++ b/dlclivegui/gui/main_window.py
@@ -2363,6 +2363,18 @@ class DLCLiveMainWindow(QMainWindow):
         self._update_dlc_controls_enabled()
 
     def _stop_inference(self, show_message: bool = True) -> None:
+        if self._rec_manager.is_active:
+            answer = QMessageBox.question(
+                self,
+                "Stop inference while recording?",
+                "This will stop any currently running DLC-processor. \n"
+                "File saving will not be handled via standard stop-recording hook."
+                "The processor might still save it's own data now, but this will not be paired with the recording.\n\n"
+                "Stop inference anyway?",
+            )
+            if answer != QMessageBox.Yes:
+                return
+
         was_active = self._dlc_active
         self._dlc_active = False
         self._dlc_initialized = False

--- a/dlclivegui/services/dlc_processor.py
+++ b/dlclivegui/services/dlc_processor.py
@@ -277,6 +277,7 @@ class DLCLiveProcessor(QObject):
                 "Shutdown requested but worker thread is still alive; DLCLive instance may not be fully released."
             )
             return
+        self._cleanup_processor()
         self._dlc = None
         self._initialized = False
 


### PR DESCRIPTION
**Summary**
Two defensive fixes on the GUI side to prevent silently losing processor
outputs when the DLC processor shuts down before the recording-stopped
hook fires.

The custom processor plugin `dlc_inference_w_pd_sync` saves its legacy
outputs (PROC pickle, DLC HDF5, timestamp NPY) and performs DB-compatible
file copies through `on_recording_stopped()`.  

some non-standard ways of ending the experiment could bypass
this hook

1. **Any `closeEvent`**: the shutdown skipped `_cleanup_processor()` when the worker thread
   stopped cleanly.  After https://github.com/MMathisLab/FreelyMovingVR4Mice/pull/329, the processor should now save it's own data when stopping. So cleanup of the processor is good here and safe.
   
2. **Stop inference while recording**:  `_stop_inference()` stops
   the processor via `_dlc.reset()` before the recording stops.  When recording is later stopped,
   `_notify_processor_recording_stopped()` finds no processor instance.
   
   
**changes:**
1.  Add the missing `self._cleanup_processor()` call in the clean-shutdown
branch of `shutdown()`, so that processor resources are properly released
and (with the processor-side fix) data is saved before the window closes.
2. When the user clicks "Stop inference" while recording is active, a
`QMessageBox.question` dialog now appears warning that legacy output
copies will be skipped and recommending to stop recording first.  If the
user proceeds anyway, the processor saves its core data through its own
`stop()` path.  No prompt appears when recording is not active.